### PR TITLE
Fix: 스토어 변경시 발생하는 훅 호출 에러 수정 #31

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": ["react", "@typescript-eslint", "eslint-plugin-prettier"],
+  "plugins": ["react", "@typescript-eslint", "eslint-plugin-prettier","react-hooks/recommended"],
   "extends": [
     "airbnb",
     "airbnb/hooks",
@@ -17,6 +17,7 @@
     "react/react-in-jsx-scope": "off",
     "prettier/prettier": "error",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-var-requires": 0
+    "@typescript-eslint/no-var-requires": 0,
+    "react-hooks/rules-of-hooks": "error"
   }
 }

--- a/src/components/bill/BillBox.tsx
+++ b/src/components/bill/BillBox.tsx
@@ -27,6 +27,10 @@ const BillBox = ({ data }: any) => {
 			return;
 		}
 
+		if (!userInfo.saved_tracklist) {
+			userInfo.saved_tracklist = [];
+		}
+
 		if (userInfo.saved_tracklist.includes(billId)) {
 			openConfirm("ALREADY_OWN_PLAYLIST");
 			return;

--- a/src/components/bill/BillBox_User.tsx
+++ b/src/components/bill/BillBox_User.tsx
@@ -23,6 +23,7 @@ import useUpdateProfileMutation from "@/hooks/useUpdateUserInfoMutation";
 const BillBox_User = ({ data }: any) => {
 	const { name, owner, created_at, tracks, analysis, color, id, likes } = data;
 	const userInfo = useUserStore((state) => state.userInfo);
+  
 	const [isHearted, setIsHearted] = useState(
 		userInfo.liked_tracklist?.includes(id!) ?? false,
 	);
@@ -66,7 +67,7 @@ const BillBox_User = ({ data }: any) => {
 			return;
 		}
 
-		if (userInfo.saved_tracklist.includes(id)) {
+		if (userInfo.saved_tracklist && userInfo.saved_tracklist.includes(id)) {
 			openConfirm("ALREADY_OWN_PLAYLIST");
 		}
 

--- a/src/components/bill/BillButtonListSection.tsx
+++ b/src/components/bill/BillButtonListSection.tsx
@@ -54,8 +54,6 @@ const BillButtonListSection = ({
 		setNowPlayList(newNowPlayTracklist);
 		setCurrentTrack(billTracks[0]);
 
-    console.log(billTracks)
-
 		//로그인 유저면 db 업데이트
 		if (userInfo.id) {
 			addNowPlayTracklistAndPlaySongTableMutation({

--- a/src/components/bill/BillItem_User.tsx
+++ b/src/components/bill/BillItem_User.tsx
@@ -8,6 +8,7 @@ import { CirclePlaySmall, StandardVertex } from "..";
 import defaultAlbumImg from "@/assets/images/defaultAlbumImage.png";
 import useUpdateProfileMutation from "@/hooks/useUpdateUserInfoMutation";
 import { useShallow } from "zustand/react/shallow";
+import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 
 const BillItem_User = ({
 	track,
@@ -26,12 +27,18 @@ const BillItem_User = ({
 		]),
 	);
 
+	const setResetMusicDrawer = useMusicDrawerStore(
+		useShallow((state) => state.resetStore),
+	);
+
 	const userInfo = useUserStore((state) => state.userInfo);
 
 	const { mutate: addCurrentTrackTableMutation } =
 		useUpdateProfileMutation(addCurrentTrackTable);
 
 	const handleClickPreviewPlayButton = (track: Track) => {
+		setResetMusicDrawer();
+
 		setCurrentTrack(track);
 		addTrackToNowPlay(track);
 		setIsPlaying(true);

--- a/src/components/common/CommonTrackItem.tsx
+++ b/src/components/common/CommonTrackItem.tsx
@@ -9,6 +9,7 @@ import { CirclePlaySmall } from "..";
 import MoreIcon from "@/assets/svgs/MoreIcon.svg?react";
 import useUpdateProfileMutation from "@/hooks/useUpdateUserInfoMutation";
 import { useShallow } from "zustand/react/shallow";
+import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 
 const CommonTrackItem = ({
 	data,
@@ -29,6 +30,10 @@ const CommonTrackItem = ({
 	);
 	const userInfo = useUserStore((state) => state.userInfo);
 
+	const setResetMusicDrawer = useMusicDrawerStore(
+		useShallow((state) => state.resetStore),
+	);
+
 	//현재재생목록에 추가 및 지금 재생
 	const { mutate: addCurrentTrackTableMutation } =
 		useUpdateProfileMutation(addCurrentTrackTable);
@@ -42,6 +47,8 @@ const CommonTrackItem = ({
 	};
 
 	const handleClickPlayButton = (track: Track) => {
+		setResetMusicDrawer();
+
 		addTrackToNowPlay(track);
 		setCurrentTrack(track);
 		setIsPlaying(true);

--- a/src/components/musicPlayer/MusicPlayerAlbumImage.tsx
+++ b/src/components/musicPlayer/MusicPlayerAlbumImage.tsx
@@ -1,0 +1,15 @@
+import { StandardVertex } from "@/components/svgComponents";
+
+interface AlbumImageProps {
+	imageUrl: string;
+	altText: string;
+}
+
+const MusicPlayerAlbumImage = ({ imageUrl, altText }: AlbumImageProps) => (
+	<div className="relative mr-8 shrink-0 cursor-pointer">
+		<img src={imageUrl} alt={altText} className="h-48 w-48" />
+		<StandardVertex className="absolute top-0 h-48 text-black" />
+	</div>
+);
+
+export default MusicPlayerAlbumImage;

--- a/src/components/musicPlayer/MusicPlayerBar.tsx
+++ b/src/components/musicPlayer/MusicPlayerBar.tsx
@@ -68,8 +68,6 @@ const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
 		preview_url: "",
 	};
 
-  console.log(currentTrack)
-
 	return (
 		<>
 			<aside

--- a/src/components/musicPlayer/MusicPlayerBar.tsx
+++ b/src/components/musicPlayer/MusicPlayerBar.tsx
@@ -6,7 +6,7 @@ import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 import defaultAlbumImage from "@/assets/images/defaultAlbumImage.png";
 import { StandardVertex } from "@/components/svgComponents";
 import MusicPlayerProgressBar from "./MusicPlayerProgressBar";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Portal from "@/utils/portal";
 import MusicPlayerFullScreen from "./MusicPlayerFullScreen";
 import { MusicPlayerBarProps } from "@/types/playerTypes";
@@ -27,16 +27,35 @@ const AlbumImage = ({ imageUrl, altText }: AlbumImageProps) => (
 );
 
 const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
+	// 음악 서랍인지 아닌지 판별
 	const isMusicDrawer = useMusicDrawerStore((state) => state.isMusicDrawer);
+	const [isMusicDrawerState, setIsMusicDrawerState] = useState(isMusicDrawer);
 
-	let usePlayerControlsHook = isMusicDrawer
+	// 음악 서랍서 재생중인지 아닌지 판별
+	const isPlaying_MusicDrawerState = useMusicDrawerStore(
+		(state) => state.isPlaying_MusicDrawer,
+	);
+	const setIsPlaying_MusicDrawer = useMusicDrawerStore(
+		(state) => state.setIsPlaying_MusicDrawer,
+	);
+
+	const [musicDrawerPlayCheck, setMusicDrawerPlayCheck] = useState(
+		isPlaying_MusicDrawerState,
+	);
+
+	// 첫 마운트시에 로컬스토리지의 재생 현황 체크하고 true일 경우 기본값으로 변경하기 위한 useEffect
+	useEffect(() => {
+		if (isPlaying_MusicDrawerState) {
+			setIsPlaying_MusicDrawer(false);
+			setMusicDrawerPlayCheck(false);
+		}
+	}, [musicDrawerPlayCheck]);
+
+	let usePlayerControlsHook = isMusicDrawerState
 		? usePlayerControlsLocal
 		: usePlayerControls;
 
-	// isMusicDrawer의 값에 따라서 usePlayerControlsHook랑 isPlaying, currentTrack이 바뀐다는것을
-	// useEffect안에서 zustand subscribe함수를 써서 사용해보기
-
-	const [isPlaying, currentTrack] = isMusicDrawer
+	const [isPlaying, currentTrack] = isMusicDrawerState
 		? useMusicDrawerStore(
 				useShallow((state) => [
 					state.isPlaying_MusicDrawer,

--- a/src/components/musicPlayer/MusicPlayerBarMusicDrawer.tsx
+++ b/src/components/musicPlayer/MusicPlayerBarMusicDrawer.tsx
@@ -1,5 +1,6 @@
 import { useModal } from "@/hooks/useModal";
-import usePlayerControls from "@/hooks/usePlayerControls";
+import usePlayerControlsMusicDrawer from "@/hooks/usePlayerControlsMusicDrawer";
+import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 import defaultAlbumImage from "@/assets/images/defaultAlbumImage.png";
 import MusicPlayerProgressBar from "./MusicPlayerProgressBar";
 import { useEffect } from "react";
@@ -10,7 +11,7 @@ import PlayerControls from "./MusicPlayerControls";
 import TrackInfo from "./PlayerTrackInfo";
 import MusicPlayerAlbumImage from "./MusicPlayerAlbumImage";
 
-const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
+const MusicPlayerBarMusicDrawer = ({ propsClassName }: MusicPlayerBarProps) => {
 	const {
 		handleClickPlayButton: playToggle,
 		handleClickNextButton: nextBtn,
@@ -20,8 +21,36 @@ const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
 		currentTrack,
 		isPlaying,
 		startPlayback,
-	} = usePlayerControls();
+	} = usePlayerControlsMusicDrawer();
 
+	// 음악 서랍서 재생중인지 재생목록서 아닌지 체크 및 세터
+	const setIsPlaying_MusicDrawer = useMusicDrawerStore(
+		(state) => state.setIsPlaying_MusicDrawer,
+	);
+
+	// 새로고침 시 전역 상태(isPlaying)를 false로 설정하는 useEffect
+	useEffect(() => {
+		const handleBeforeUnload = () => {
+			setIsPlaying_MusicDrawer(false);
+		};
+
+		window.addEventListener("beforeunload", handleBeforeUnload);
+
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+		};
+	}, [setIsPlaying_MusicDrawer]);
+
+	// intervalIdRef의 변경에 대한 처리를 위한 useEffect
+	useEffect(() => {
+		return () => {
+			if (intervalIdRef.current) {
+				clearInterval(intervalIdRef.current);
+			}
+		};
+	}, [isPlaying]);
+
+	// isPlaying이 변경될 때 음악을 재생하거나 중지하는 useEffect
 	useEffect(() => {
 		if (isPlaying) {
 			startPlayback();
@@ -30,14 +59,6 @@ const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
 			audioRef.current = null;
 		};
 	}, []);
-
-	useEffect(() => {
-		return () => {
-			if (intervalIdRef.current) {
-				clearInterval(intervalIdRef.current);
-			}
-		};
-	}, [isPlaying]);
 
 	const { openModal, modalType } = useModal();
 
@@ -107,4 +128,4 @@ const MusicPlayerBar = ({ propsClassName }: MusicPlayerBarProps) => {
 	);
 };
 
-export default MusicPlayerBar;
+export default MusicPlayerBarMusicDrawer;

--- a/src/components/mymusic/MusicDrawerItem.tsx
+++ b/src/components/mymusic/MusicDrawerItem.tsx
@@ -4,19 +4,23 @@ import { StandardVertex } from "..";
 import defaultAlbumImage from "@/assets/images/defaultAlbumImage.png";
 import MoreIcon from "@/assets/svgs/MoreIcon.svg?react";
 import useMusicDrawerStore from "@/zustand/musicDrawerStore";
+import { useShallow } from "zustand/react/shallow";
 
 const MusicDrawerItem = ({ track, setSelectedTrack, isSelected }: any) => {
 	const navigate = useNavigate();
 	const { name, artists, album } = track;
 	const { openModal } = useModal();
-	const setIsPlaying_MusicDrawer = useMusicDrawerStore(
-		(state) => state.setIsPlaying_MusicDrawer,
-	);
-	const setCurrentTrack_MusicDrawer = useMusicDrawerStore(
-		(state) => state.setCurrentTrack_MusicDrawer,
-	);
-	const setIsMusicDrawer = useMusicDrawerStore(
-		(state) => state.setIsMusicDrawer,
+
+	const [
+		setIsPlaying_MusicDrawer,
+		setCurrentTrack_MusicDrawer,
+		setIsMusicDrawer,
+	] = useMusicDrawerStore(
+		useShallow((state) => [
+			state.setIsPlaying_MusicDrawer,
+			state.setCurrentTrack_MusicDrawer,
+			state.setIsMusicDrawer,
+		]),
 	);
 
 	const handleClickTrack = () => {

--- a/src/components/mymusic/MusicDrawerItem.tsx
+++ b/src/components/mymusic/MusicDrawerItem.tsx
@@ -5,11 +5,23 @@ import defaultAlbumImage from "@/assets/images/defaultAlbumImage.png";
 import MoreIcon from "@/assets/svgs/MoreIcon.svg?react";
 import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 import { useShallow } from "zustand/react/shallow";
+import { setCurrentTrackAndPositionTable } from "@/api/supabase/profilesTableAccessApis";
+import useUpdateProfileMutation from "@/hooks/useUpdateUserInfoMutation";
+import useUserStore from "@/zustand/userStore";
+
+const initialTrack = {
+	name: "",
+	album: { images: [{ url: "" }] },
+	artists: [],
+	duration_ms: 0,
+	preview_url: "",
+};
 
 const MusicDrawerItem = ({ track, setSelectedTrack, isSelected }: any) => {
 	const navigate = useNavigate();
 	const { name, artists, album } = track;
 	const { openModal } = useModal();
+	const userInfo = useUserStore((state) => state.userInfo);
 
 	const [
 		setIsPlaying_MusicDrawer,
@@ -23,10 +35,20 @@ const MusicDrawerItem = ({ track, setSelectedTrack, isSelected }: any) => {
 		]),
 	);
 
+	const { mutate: setCurrentTrackAndPositionTableMutation } =
+		useUpdateProfileMutation(setCurrentTrackAndPositionTable);
+
 	const handleClickTrack = () => {
 		setIsMusicDrawer(true);
 		setCurrentTrack_MusicDrawer(track);
 		setIsPlaying_MusicDrawer(true);
+
+		setCurrentTrackAndPositionTableMutation({
+			prevNowPlayTracklist: userInfo.nowplay_tracklist,
+			track: initialTrack,
+			playingPosition: 0,
+			userId: userInfo.id,
+		});
 	};
 
 	const handleClickAlbum = (

--- a/src/components/mymusic/MusicListItem.tsx
+++ b/src/components/mymusic/MusicListItem.tsx
@@ -58,16 +58,15 @@ const MusicListItem = ({
 		setResetMusicDrawer();
 		setIsMusicDrawer(false);
 		setIsPlaying_MusicDrawer(false);
-		if (!isPlaying_MusicDrawer) {
-			setCurrentTrack(track);
-			setIsPlaying(true);
-			setCurrentTrackAndPositionTableMutation.mutateAsync({
-				prevNowPlayTracklist: userInfo.nowplay_tracklist,
-				track,
-				playingPosition: 0,
-				userId: userInfo.id,
-			});
-		}
+
+		setCurrentTrack(track);
+		setIsPlaying(true);
+		setCurrentTrackAndPositionTableMutation.mutateAsync({
+			prevNowPlayTracklist: userInfo.nowplay_tracklist,
+			track,
+			playingPosition: 0,
+			userId: userInfo.id,
+		});
 	};
 
 	const handleClickAlbum = (

--- a/src/components/mymusic/MusicListItem.tsx
+++ b/src/components/mymusic/MusicListItem.tsx
@@ -8,13 +8,13 @@ import { StandardVertex } from "..";
 import defaultAlbumImage from "@/assets/images/defaultAlbumImage.png";
 import MoreIcon from "@/assets/svgs/MoreIcon.svg?react";
 import useMusicDrawerStore from "@/zustand/musicDrawerStore";
+import { useShallow } from "zustand/react/shallow";
 
 const MusicListItem = ({
 	track,
 	setSelectedTrack,
 	isSelected,
 	dragItem,
-
 	dragEnter,
 	dragStart,
 	idx,
@@ -27,16 +27,18 @@ const MusicListItem = ({
 	const setIsPlaying = usePlayNowStore((state) => state.setIsPlaying);
 	const userInfo = useUserStore((state) => state.userInfo);
 	const queryClient = useQueryClient();
-	const setIsMusicDrawer = useMusicDrawerStore(
-		(state) => state.setIsMusicDrawer,
-	);
-	const setResetMusicDrawer = useMusicDrawerStore((state) => state.resetStore);
-
-	const setIsPlaying_MusicDrawer = useMusicDrawerStore(
-		(state) => state.setIsPlaying_MusicDrawer,
-	);
-	const isPlaying_MusicDrawer = useMusicDrawerStore(
-		(state) => state.isPlaying_MusicDrawer,
+	const [
+		setIsMusicDrawer,
+		setResetMusicDrawer,
+		setIsPlaying_MusicDrawer,
+		isPlaying_MusicDrawer,
+	] = useMusicDrawerStore(
+		useShallow((state) => [
+			state.setIsMusicDrawer,
+			state.resetStore,
+			state.setIsPlaying_MusicDrawer,
+			state.isPlaying_MusicDrawer,
+		]),
 	);
 
 	//현재 음악 설정 및 재생

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -4,7 +4,13 @@ import { SearchIcon, StandardPixelBorder } from "..";
 import RecentSearchList from "./RecentSearchList";
 import useSearchStore from "@/zustand/searchStore";
 
-const SearchBar = () => {
+const SearchBar = ({
+	searchBarState,
+	handleSearchBarToggle,
+}: {
+	searchBarState: boolean;
+	handleSearchBarToggle: (newState: any) => void;
+}) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const navigate = useNavigate();
 	const { search } = useLocation();
@@ -12,10 +18,9 @@ const SearchBar = () => {
 	const q = queryParams.get("q");
 	const [input, setInput] = useState<string>(q ? q : "");
 	const saveKeywordToStorage = useSearchStore((state) => state.setLocalStorage);
-	const [recentSearchToggle, setRecentSearchToggle] = useState<boolean>(true);
 
 	const handleRecentSearchToggle = () => {
-		setRecentSearchToggle((prev) => !prev);
+		handleSearchBarToggle((prev: boolean) => !prev);
 	};
 
 	useEffect(() => {
@@ -37,7 +42,7 @@ const SearchBar = () => {
 		if (input.trim() !== "") {
 			handleNavigateToResults(input);
 			saveKeywordToStorage(input);
-			setRecentSearchToggle(false);
+			handleSearchBarToggle(false);
 		}
 	};
 
@@ -48,7 +53,7 @@ const SearchBar = () => {
 		if (e.key === "Enter" && input.trim() !== "") {
 			handleNavigateToResults(input);
 			saveKeywordToStorage(input);
-			setRecentSearchToggle(false);
+			handleSearchBarToggle(false);
 		}
 	};
 
@@ -72,9 +77,9 @@ const SearchBar = () => {
 				className="absolute left-20 top-30 h-30 w-[70%] bg-mainBlack text-mainWhite outline-none"
 			/>
 
-			{recentSearchToggle && (
+			{searchBarState && (
 				<RecentSearchList
-					handleRecentSearchToggle={setRecentSearchToggle}
+					handleRecentSearchToggle={handleSearchBarToggle}
 					handleNavigateToResults={handleNavigateToResults}
 				/>
 			)}

--- a/src/constants/confirmText.ts
+++ b/src/constants/confirmText.ts
@@ -41,7 +41,7 @@ const CONFIRM_TYPE: Readonly<ConfirmType> = Object.freeze({
 	SHARE_URL_COPY: ["링크가 클립보드에 복사되었습니다."],
 	CONFIRM: ["확인"],
 	CANCEL: ["취소"],
-	MUSIC_SHELF_SAVE: ["음악서랍에 저장이 완료되었습니다."],
+	MUSIC_SHELF_SAVE: ["음악서랍에 저장되었습니다."],
 });
 
 export default CONFIRM_TYPE;

--- a/src/hooks/usePlayerControls.ts
+++ b/src/hooks/usePlayerControls.ts
@@ -90,7 +90,6 @@ const usePlayerControls = () => {
 	const updatePlayback = (newTrack?: Track) => {
 		const currentPlayingTrack = usePlayNowStore.getState().currentTrack;
 
-		console.log(newTrack);
 		if (newTrack) setCurrentTrack(newTrack);
 		const trackToPlay = newTrack || currentPlayingTrack;
 		audioRef.current!.src = trackToPlay?.preview_url!;

--- a/src/hooks/usePlayerControls.ts
+++ b/src/hooks/usePlayerControls.ts
@@ -14,16 +14,23 @@ const usePlayerControls = () => {
 	const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
 	const userInfo = useUserStore((state) => state.userInfo);
 
-	const [isPlaying, tracks, setIsPlaying, setPlayingPosition, setCurrentTrack] =
-		usePlayNowStore(
-			useShallow((state) => [
-				state.isPlaying, // 재생 상태 (boolean)
-				state.tracks, // 전체 트랙 (array)
-				state.setIsPlaying, // 재생 상태 변경 (play | pause)
-				state.setPlayingPosition, // progress position
-				state.setCurrentTrack, // 현재 재생트랙 지정
-			]),
-		);
+	const [
+		isPlaying,
+		tracks,
+		setIsPlaying,
+		setPlayingPosition,
+		setCurrentTrack,
+		currentTrack,
+	] = usePlayNowStore(
+		useShallow((state) => [
+			state.isPlaying, // 재생 상태 (boolean)
+			state.tracks, // 전체 트랙 (array)
+			state.setIsPlaying, // 재생 상태 변경 (play | pause)
+			state.setPlayingPosition, // progress position
+			state.setCurrentTrack, // 현재 재생트랙 지정
+			state.currentTrack,
+		]),
+	);
 
 	const { mutate: setCurrentTrackAndPositionTableMutation } =
 		useUpdateProfileMutation(setCurrentTrackAndPositionTable);
@@ -201,6 +208,8 @@ const usePlayerControls = () => {
 		audioRef,
 		intervalIdRef,
 		startPlayback,
+		currentTrack,
+		isPlaying,
 	};
 };
 

--- a/src/hooks/usePlayerControlsLocal.ts
+++ b/src/hooks/usePlayerControlsLocal.ts
@@ -27,7 +27,6 @@ const usePlayerControlsLocal = () => {
 		intervalIdRef.current = setInterval(() => {
 			const currentTrack =
 				useMusicDrawerStore.getState().currentTrack_MusicDrawer;
-
 			const tracks = useMusicDrawerStore.getState().tracks_MusicDrawer;
 
 			const isLastSong =
@@ -80,9 +79,9 @@ const usePlayerControlsLocal = () => {
 			audioRef.current!.src = trackToPlay?.preview_url!;
 
 			setPlayingPosition(0);
-			audioRef.current!.load();
+			audioRef.current?.load();
 
-			audioRef.current!.addEventListener("canplay", () => {
+			audioRef.current?.addEventListener("canplay", () => {
 				startPlayback();
 			});
 		},
@@ -96,7 +95,7 @@ const usePlayerControlsLocal = () => {
 		} else {
 			startPlayback();
 		}
-	}, [isPlaying, startPlayback, pausePlayback]);
+	}, [isPlaying, tracks, setIsPlaying, setPlayingPosition, setCurrentTrack]);
 
 	// 이전 곡 재생 버튼
 	const handleClickPrevButton = useCallback(() => {

--- a/src/hooks/usePlayerControlsMusicDrawer.ts
+++ b/src/hooks/usePlayerControlsMusicDrawer.ts
@@ -4,20 +4,27 @@ import useMusicDrawerStore from "@/zustand/musicDrawerStore";
 import { Track } from "@/types/recommendTypes";
 import { shallow } from "zustand/shallow";
 
-const usePlayerControlsLocal = () => {
+const usePlayerControlsMusicDrawer = () => {
 	const audioRef = useRef<HTMLAudioElement | null>(null);
 	const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
 
-	const [isPlaying, tracks, setIsPlaying, setPlayingPosition, setCurrentTrack] =
-		useMusicDrawerStore(
-			useShallow((state) => [
-				state.isPlaying_MusicDrawer,
-				state.tracks_MusicDrawer,
-				state.setIsPlaying_MusicDrawer,
-				state.setPlayingPosition_MusicDrawer,
-				state.setCurrentTrack_MusicDrawer,
-			]),
-		);
+	const [
+		isPlaying,
+		tracks,
+		setIsPlaying,
+		setPlayingPosition,
+		setCurrentTrack,
+		currentTrack,
+	] = useMusicDrawerStore(
+		useShallow((state) => [
+			state.isPlaying_MusicDrawer,
+			state.tracks_MusicDrawer,
+			state.setIsPlaying_MusicDrawer,
+			state.setPlayingPosition_MusicDrawer,
+			state.setCurrentTrack_MusicDrawer,
+			state.currentTrack_MusicDrawer,
+		]),
+	);
 
 	// 음악 재생
 	const startPlayback = useCallback(() => {
@@ -159,6 +166,15 @@ const usePlayerControlsLocal = () => {
 		}
 	}, [updatePlayback]);
 
+	useEffect(() => {
+		return () => {
+			if (intervalIdRef.current) {
+				clearInterval(intervalIdRef.current);
+			}
+			audioRef.current = null;
+		};
+	}, []);
+
 	return {
 		handleClickPlayButton,
 		handleClickNextButton,
@@ -166,7 +182,9 @@ const usePlayerControlsLocal = () => {
 		audioRef,
 		intervalIdRef,
 		startPlayback,
+		currentTrack,
+		isPlaying,
 	};
 };
 
-export default usePlayerControlsLocal;
+export default usePlayerControlsMusicDrawer;

--- a/src/pages/Page-Entry.tsx
+++ b/src/pages/Page-Entry.tsx
@@ -15,7 +15,7 @@ const Entry = () => {
 	};
 
 	const moveToSignIn = () => {
-		navigate("/signin");
+		navigate("/login");
 	};
 
 	const moveToHome = () => {

--- a/src/pages/Page-MyMusicShelfDetail.tsx
+++ b/src/pages/Page-MyMusicShelfDetail.tsx
@@ -84,7 +84,8 @@ const MyMusicShelfDetail = () => {
 						<ArrowDown />
 					</button>
 				</section>
-				<ul className="mx-auto mb-140 min-h-[80svh] w-full border">
+				
+        <ul className="mx-auto mb-140 min-h-[80svh] w-full border">
 					<li className="group relative flex h-62 w-full cursor-pointer items-center justify-between border-b-1 pl-12 pr-16 hover:bg-mainGray300">
 						<p className="truncate text-16 desktop:text-18 ">
 							{data.name} (

--- a/src/pages/Page-Search.tsx
+++ b/src/pages/Page-Search.tsx
@@ -1,10 +1,26 @@
 import SearchBar from "@/components/search/SearchBar";
 import SearchResultWrap from "@/components/search/SearchResultWrap";
+import { useState } from "react";
 
 const Search = () => {
+	const [recentSearchToggle, setRecentSearchToggle] = useState<boolean>(true);
+
+	const handleSearchBar = (e: React.MouseEvent<HTMLDivElement>) => {
+		const target = e.target as HTMLInputElement;
+		if (target.tagName !== "INPUT") {
+			setRecentSearchToggle(false);
+		}
+	};
+
 	return (
-		<div className={`relative h-[100svh] overflow-y-auto px-20 desktop:px-60`}>
-			<SearchBar />
+		<div
+			onClick={handleSearchBar}
+			className={`relative h-[100svh] overflow-y-auto px-20 desktop:px-60`}
+		>
+			<SearchBar
+				searchBarState={recentSearchToggle}
+				handleSearchBarToggle={setRecentSearchToggle}
+			/>
 			<SearchResultWrap />
 		</div>
 	);

--- a/src/pages/Wrapper.tsx
+++ b/src/pages/Wrapper.tsx
@@ -9,6 +9,7 @@ import usePlayNowStore from "@/zustand/playNowStore";
 import useUserStore from "@/zustand/userStore";
 import MainMetaTag from "@/components/common/MainMetaTag";
 import useMusicDrawerStore from "@/zustand/musicDrawerStore";
+import MusicPlayerBarMusicDrawer from "@/components/musicPlayer/MusicPlayerBarMusicDrawer";
 
 // 아래 경로에서는 보이지 않도록 지정
 const SHOW_PATH_REGEX =
@@ -17,9 +18,11 @@ const SHOW_PATH_REGEX =
 const Wrapper = () => {
 	const isLoggedin = useUserStore((state) => state.userInfo.id);
 	const isMusicDrawer = useMusicDrawerStore((state) => state.isMusicDrawer);
+
 	const currentTrack = isMusicDrawer
 		? useMusicDrawerStore((state) => state.currentTrack_MusicDrawer)
 		: usePlayNowStore((state) => state.currentTrack);
+
 	const { pathname } = useLocation();
 	const isShowMusicPlayerBar = SHOW_PATH_REGEX.test(pathname);
 	const isDownMusicPlayerBar =
@@ -27,6 +30,25 @@ const Wrapper = () => {
 		pathname.split("/").length <= 4 &&
 		!pathname.split("/")[3];
 
+	const renderBar = (boo: boolean) => {
+		return boo ? (
+			<MusicPlayerBarMusicDrawer
+				propsClassName={
+					!isLoggedin && isDownMusicPlayerBar
+						? "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0"
+						: "bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray"
+				}
+			/>
+		) : (
+			<MusicPlayerBar
+				propsClassName={
+					!isLoggedin && isDownMusicPlayerBar
+						? "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0"
+						: "bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray"
+				}
+			/>
+		);
+	};
 	return (
 		<div>
 			<MainMetaTag />
@@ -36,15 +58,7 @@ const Wrapper = () => {
 				<Suspense fallback={<Spinner />}>
 					<Outlet />
 					<Portal>
-						{isShowMusicPlayerBar && currentTrack && (
-							<MusicPlayerBar
-								propsClassName={
-									!isLoggedin && isDownMusicPlayerBar
-										? "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0"
-										: "bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray"
-								}
-							/>
-						)}
+						{isShowMusicPlayerBar && currentTrack && renderBar(isMusicDrawer)}
 					</Portal>
 				</Suspense>
 				{isShowMusicPlayerBar && <NavBar />}

--- a/src/pages/Wrapper.tsx
+++ b/src/pages/Wrapper.tsx
@@ -15,7 +15,14 @@ import MusicPlayerBarMusicDrawer from "@/components/musicPlayer/MusicPlayerBarMu
 const SHOW_PATH_REGEX =
 	/^(?!\/$|\/recommend|\/entry|\/signupwithemail|\/signinwithemail|\/profileedit).+/;
 
+const MUSIC_PLAYER_STYLE = {
+	isShow: "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0",
+	isNotShow:
+		"bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray",
+};
+
 const Wrapper = () => {
+	const { pathname } = useLocation();
 	const isLoggedin = useUserStore((state) => state.userInfo.id);
 	const isMusicDrawer = useMusicDrawerStore((state) => state.isMusicDrawer);
 
@@ -23,7 +30,6 @@ const Wrapper = () => {
 		? useMusicDrawerStore((state) => state.currentTrack_MusicDrawer)
 		: usePlayNowStore((state) => state.currentTrack);
 
-	const { pathname } = useLocation();
 	const isShowMusicPlayerBar = SHOW_PATH_REGEX.test(pathname);
 	const isDownMusicPlayerBar =
 		pathname.includes("/bill/") &&
@@ -35,20 +41,21 @@ const Wrapper = () => {
 			<MusicPlayerBarMusicDrawer
 				propsClassName={
 					!isLoggedin && isDownMusicPlayerBar
-						? "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0"
-						: "bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray"
+						? MUSIC_PLAYER_STYLE.isNotShow
+						: MUSIC_PLAYER_STYLE.isNotShow
 				}
 			/>
 		) : (
 			<MusicPlayerBar
 				propsClassName={
 					!isLoggedin && isDownMusicPlayerBar
-						? "bottom-0 border-x-white border-x-[1.8px] desktop:border-x-0"
-						: "bottom-66 border border-t-0 desktop:border-x-white desktop:border-x-[1.8px] border-b-mainGray"
+						? MUSIC_PLAYER_STYLE.isNotShow
+						: MUSIC_PLAYER_STYLE.isNotShow
 				}
 			/>
 		);
 	};
+
 	return (
 		<div>
 			<MainMetaTag />

--- a/src/zustand/musicDrawerStore.ts
+++ b/src/zustand/musicDrawerStore.ts
@@ -66,7 +66,7 @@ const useMusicDrawerStore = create(
 				setNowPlayList_MusicDrawer: (tracklist: Track[]) => {
 					set((state: NowPlayList_MusicDrawer) => ({
 						...state,
-						tracks_MusicDrawer: tracklist,
+						tracks_MusicDrawer: tracklist.filter((track) => track.preview_url),
 					}));
 				},
 


### PR DESCRIPTION
## 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->

## 상세 작업 내용
- [x]  음악서랍 초기저장시 빈배열일 경우 null이라 includes 메서드 불가하므로 방어 코드 추가
- [x]  재생목록, 음악서랍 배열 비어있을시 텍스트 공통 상수로 빼서 처리
- [x]  음악서랍 <=> 재생목록 전환시 바로 재생되지 않고 렌더링이 한번 발생후 재생되던 에러 수정
- [x]  음악 서랍서 새로고침시 계속 재생중이던 문제 beforeunload 이벤트 사용해서 재생 막기
- [x]  음악서랍 재생시 여전히 재생으로 표시되던 재생목록의 아이템 유저가 헷갈리지 않도록 DB테이블에서 currentTrack을 초기트랙(빈값)으로 설정해두기
- [x]  음악 서랍에서 재생중일때 [검색 창, 유저 영수증]에서 플레이 버튼 누르면 재생 안되는 문제 수정
- [x]  서치바 인풋 외의 바탕 클릭시 토글 해제(false)되도록 수정

### 이하 배포 후 수정

- [ ]  로그아웃 했을때 음악 서랍도 제거 하기
## ETC
<!-- 기타사항 -->

## 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->
- Close #31 
