### PR TITLE
Refactor: 삭제 시 좋아요목록, 음악서랍 값 수정하기

### DIFF
--- a/src/api/supabase/deletedTracksTableAccessApis.ts
+++ b/src/api/supabase/deletedTracksTableAccessApis.ts
@@ -1,0 +1,65 @@
+import { DeletedTrack } from "@/types/deletedtracklistTypes";
+import supabase from "./client";
+
+// 모든 유저의 좋아요, 저장된 트랙리스트에 삭제된 빌지가 있으면 없애기
+export interface DeleteTracklistProps {
+	prevTracklist: string[];
+	type: string;
+	userId: string;
+}
+
+export const deleteTracklistInComparesTracklist = async ({
+	prevTracklist,
+	type,
+	userId,
+}: DeleteTracklistProps) => {
+	try {
+		const promises = prevTracklist
+			.filter((item) => item.length === 36)
+			.map(async (tracksId: string) => {
+				const { data }: { data: DeletedTrack[] | null } = await supabase
+					.from("deleted_tracks")
+					.select("*")
+					.eq("id", tracksId);
+				if (!data?.length) return null;
+				return data[0].id;
+			});
+		const filteredData = (await Promise.all(promises)).filter(
+			(item) => item !== null,
+		);
+
+		if (!filteredData.length) return null;
+
+		const updateData = prevTracklist.filter(
+			(item) => !filteredData.includes(item),
+		);
+
+		const { data } = await supabase
+			.from("profiles")
+			.update(
+				type === "liked"
+					? { liked_tracklist: updateData }
+					: { saved_tracklist: updateData },
+			)
+			.eq("id", userId)
+			.select();
+
+		return data![0];
+	} catch (error) {
+		console.error("Error in getArtistId:", error);
+		throw error;
+	}
+};
+
+export const addDeletedTracklist = async ({ billId }: { billId: string }) => {
+	try {
+		const { data } = await supabase
+			.from("deleted_tracks")
+			.insert([{ id: billId }])
+			.select();
+
+		return data;
+	} catch (error) {
+		console.log(error);
+	}
+};

--- a/src/api/supabase/profilesTableAccessApis.ts
+++ b/src/api/supabase/profilesTableAccessApis.ts
@@ -102,7 +102,9 @@ export const updateLikedTracklist = async ({
 			.update({
 				liked_tracklist: isAlreadyLiked
 					? prevLikedTracklist?.filter((tracklist) => tracklist !== billId)
-					: [...prevLikedTracklist, billId],
+					: prevLikedTracklist
+						? [...prevLikedTracklist, billId]
+						: [billId],
 			})
 			.eq("id", userId)
 			.select();
@@ -130,7 +132,9 @@ export const addSavedTracklist = async ({
 		const { data } = await supabase
 			.from("profiles")
 			.update({
-				saved_tracklist: [...prevSavedTracklist, billId],
+				saved_tracklist: prevSavedTracklist
+					? [...prevSavedTracklist, billId]
+					: [billId],
 			})
 			.eq("id", userId)
 			.select();

--- a/src/components/profile/ProfileSmallBill.tsx
+++ b/src/components/profile/ProfileSmallBill.tsx
@@ -35,7 +35,7 @@ const ProfileSmallBill = ({
 		setIsHearted((prevIsHearted) => !prevIsHearted);
 
 		likeCountBillMutation({
-			prevLikes: likes,
+			prevLikes: data.likes,
 			billId: id!,
 			isAdd: !isHearted,
 		});
@@ -46,8 +46,6 @@ const ProfileSmallBill = ({
 			userId: userProfile.id,
 		});
 	};
-
-	const { name, likes } = data;
 
 	const totalDuration = data?.tracks.reduce(
 		(sum: number, item: any) => sum + item.duration_ms,
@@ -62,7 +60,7 @@ const ProfileSmallBill = ({
                 desktop:h-[300px] desktop:w-[250px]"
 		>
 			<SmallBillSide className="absolute top-[-15px]" />
-
+			{!data && <>삭제된 영수증 입니다.</>}
 			{data && (
 				<>
 					<p
@@ -73,7 +71,7 @@ const ProfileSmallBill = ({
                         desktop:h-60 desktop:w-180 desktop:text-20
                         "
 					>
-						{name || `${data?.owner?.username}의 영수증`}
+						{data.name || `${data?.owner?.username}의 영수증`}
 					</p>
 
 					<div

--- a/src/components/recommend/MakingBillAnimateComponent.tsx
+++ b/src/components/recommend/MakingBillAnimateComponent.tsx
@@ -1,4 +1,4 @@
-import LogoBlack from "@/assets/images/logoBlack.png";
+import LogoBlack from "@/assets/images/LogoBlack.png";
 import barcodeImg from "@/assets/images/barcode.png";
 import BILL_TEXT from "@/constants/billText";
 import { Spinner } from "..";

--- a/src/hooks/useUpdateUserInfoMutation.ts
+++ b/src/hooks/useUpdateUserInfoMutation.ts
@@ -1,5 +1,5 @@
+import { User } from "@/types/user";
 import useUserStore from "@/zustand/userStore";
-import { User } from "@supabase/supabase-js";
 import {
 	UseMutationResult,
 	useMutation,

--- a/src/hooks/useUserSession.ts
+++ b/src/hooks/useUserSession.ts
@@ -10,6 +10,7 @@ const useUserSession = () => {
 				const {
 					data: { session },
 				} = await supabase.auth.getSession();
+				if (!session) return null;
 				setUserId(session!.user.id);
 			} catch (error) {}
 			return null;

--- a/src/types/deletedtracklistTypes.ts
+++ b/src/types/deletedtracklistTypes.ts
@@ -1,0 +1,4 @@
+//DeletedTracks
+export interface DeletedTrack {
+	id: string;
+}


### PR DESCRIPTION
## 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
모든 유저의 좋아요, 저장된 트랙리스트에 삭제된 빌지가 있으면 없애기

## 상세 작업 내용
- 삭제된 빌지 목록 생성
- 좋아요 목록 진입 시 삭제 목록에 있으면 삭제 대응
- 음악서랍 진입 시 삭제 목록에 있으면 삭제 대응
- profileApi에서 prevTracklist가 없는 경우도 대응 수정  
- useUpdateProfileMutation user type 임포트 실수 수정


## ETC
<!-- 기타사항 -->

## 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->
- Close #{이슈번호}
